### PR TITLE
Fix card shadow appearance

### DIFF
--- a/mobile/src/screens/tabs/HomeScreen.tsx
+++ b/mobile/src/screens/tabs/HomeScreen.tsx
@@ -22,13 +22,15 @@ export const HomeScreen = () => {
 
       {/* Credit Card Section */}
       <View style={styles.cardSection}>
-        <Image
-          source={{
-            uri: 'https://imgur.com/Vuqf8wt.png',
-          }}
-          style={styles.creditCardImage}
-          resizeMode="contain"
-      />
+        <View style={styles.cardShadowContainer}>
+          <Image
+            source={{
+              uri: 'https://imgur.com/Vuqf8wt.png',
+            }}
+            style={styles.creditCardImage}
+            resizeMode="contain"
+          />
+        </View>
       </View>
 
       <View style={styles.buttonsSection}>
@@ -206,9 +208,13 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 250,
     borderRadius: 15,
+  },
+  cardShadowContainer: {
+    borderRadius: 15,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 4,
+    elevation: 5,
   },
-}); 
+});


### PR DESCRIPTION
## Summary
- wrap credit card image with container to show shadow properly
- add `cardShadowContainer` style for drop shadow
- keep image style for sizing only

## Testing
- `npm test` (fails: Missing script)
- `npm test` in backend (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68415279cb68832faf3505502cdac9cc