### PR TITLE
Implement detailed transactions page

### DIFF
--- a/mobile/src/data/transactions.ts
+++ b/mobile/src/data/transactions.ts
@@ -1,0 +1,27 @@
+export interface Transaction {
+  id: string;
+  counterparty: string;
+  category: string;
+  date: string;
+  amount: string;
+  type: 'sent' | 'received';
+}
+
+export const transactions: Transaction[] = [
+  {
+    id: '1',
+    counterparty: 'John Doe',
+    category: 'School',
+    date: '03 jun 2025',
+    amount: '-59€',
+    type: 'sent',
+  },
+  {
+    id: '2',
+    counterparty: 'Fontys',
+    category: 'Salary',
+    date: '02 jun 2025',
+    amount: '1000€',
+    type: 'received',
+  },
+];

--- a/mobile/src/screens/tabs/HomeScreen.tsx
+++ b/mobile/src/screens/tabs/HomeScreen.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { transactions } from '../../data/transactions';
 
 export const HomeScreen = () => {
-  // TRANSACTIONS VISUALS
-  const transactions = [
-    { id: '1', description: 'To Jonh Doe • School', date: '03 jun 2025', amount: '-59€', type: 'sent' },
-    { id: '2', description: 'From Fontys • Salary', date: '02 jun 2025', amount: '1000€', type: 'received' },
-  ];
 
   return (
     <ScrollView style={styles.container}>
@@ -71,7 +67,9 @@ export const HomeScreen = () => {
               />
             </View>
             <View style={styles.transactionDetails}>
-              <Text style={styles.transactionDescription}>{transaction.description}</Text>
+              <Text style={styles.transactionDescription}>
+                {transaction.type === 'sent' ? `To ${transaction.counterparty}` : `From ${transaction.counterparty}`} • {transaction.category}
+              </Text>
               <Text style={styles.transactionDate}>{transaction.date}</Text>
             </View>
             <Text style={[styles.transactionAmount, transaction.type === 'sent' ? styles.sentAmount : styles.receivedAmount]}>{transaction.amount}</Text>

--- a/mobile/src/screens/tabs/TransactionsScreen.tsx
+++ b/mobile/src/screens/tabs/TransactionsScreen.tsx
@@ -1,11 +1,42 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, ScrollView } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { transactions } from '../../data/transactions';
 
 export const TransactionsScreen = () => {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Transactions</Text>
-    </View>
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>TRANSACTIONS</Text>
+      {transactions.map(transaction => (
+        <View key={transaction.id} style={styles.transactionItem}>
+          <View
+            style={[
+              styles.transactionIconContainer,
+              transaction.type === 'sent' ? styles.sentIcon : styles.receivedIcon,
+            ]}
+          >
+            <Ionicons
+              name={transaction.type === 'sent' ? 'arrow-up' : 'arrow-down'}
+              size={20}
+              color="#FFFFFF"
+            />
+          </View>
+          <View style={styles.transactionDetails}>
+            <Text style={styles.transactionCounterparty}>{transaction.counterparty}</Text>
+            <Text style={styles.transactionCategory}>{transaction.category}</Text>
+            <Text style={styles.transactionDate}>{transaction.date}</Text>
+          </View>
+          <Text
+            style={[
+              styles.transactionAmount,
+              transaction.type === 'sent' ? styles.sentAmount : styles.receivedAmount,
+            ]}
+          >
+            {transaction.amount}
+          </Text>
+        </View>
+      ))}
+    </ScrollView>
   );
 };
 
@@ -13,12 +44,59 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#222222',
-    alignItems: 'center',
-    justifyContent: 'center',
+    padding: 15,
+    paddingTop: 40,
   },
   title: {
-    fontSize: 24,
+    fontSize: 18,
     fontWeight: 'bold',
-    color: '#48BF73',
-  }
-}); 
+    color: '#66BB6A',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  transactionItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#323232',
+    padding: 15,
+    borderRadius: 10,
+    marginBottom: 10,
+  },
+  transactionIconContainer: {
+    padding: 10,
+    borderRadius: 20,
+    marginRight: 15,
+  },
+  sentIcon: {
+    backgroundColor: '#444444',
+  },
+  receivedIcon: {
+    backgroundColor: '#66BB6A',
+  },
+  transactionDetails: {
+    flex: 1,
+  },
+  transactionCounterparty: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  transactionCategory: {
+    color: 'gray',
+    fontSize: 14,
+  },
+  transactionDate: {
+    color: 'gray',
+    fontSize: 12,
+  },
+  transactionAmount: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  sentAmount: {
+    color: '#FF5555',
+  },
+  receivedAmount: {
+    color: '#66BB6A',
+  },
+});


### PR DESCRIPTION
## Summary
- share transaction data in `src/data/transactions.ts`
- display transactions on home screen using shared data
- implement new Transactions page with detailed list of transactions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run` to show available scripts
- `npm test` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415594c77c832faef7573d2a432f24