### PR TITLE
Add category grouping and selection

### DIFF
--- a/mobile/src/data/transactions.ts
+++ b/mobile/src/data/transactions.ts
@@ -15,7 +15,7 @@ export const transactions: Transaction[] = [
   {
     id: '1',
     counterparty: 'John Doe',
-    category: 'School',
+    category: 'Bills',
     description: 'Tuition payment',
     date: '03 jun 2025',
     amount: '-59€',
@@ -25,7 +25,7 @@ export const transactions: Transaction[] = [
   {
     id: '2',
     counterparty: 'Fontys',
-    category: 'Salary',
+    category: 'Savings',
     description: 'Monthly salary',
     date: '02 jun 2025',
     amount: '1000€',
@@ -35,7 +35,7 @@ export const transactions: Transaction[] = [
   {
     id: '3',
     counterparty: 'Alice\'s Coffee',
-    category: 'Coffee',
+    category: 'Groceries',
     description: 'Morning coffee',
     date: '01 jun 2025',
     amount: '-4€',
@@ -45,7 +45,7 @@ export const transactions: Transaction[] = [
   {
     id: '4',
     counterparty: 'Online Store',
-    category: 'Shopping',
+    category: 'Groceries',
     description: 'Online shopping',
     date: '31 may 2025',
     amount: '-79€',
@@ -55,7 +55,7 @@ export const transactions: Transaction[] = [
   {
     id: '5',
     counterparty: 'Freelance Client',
-    category: 'Freelance',
+    category: 'Investments',
     description: 'Invoice payment',
     date: '30 may 2025',
     amount: '450€',
@@ -65,7 +65,7 @@ export const transactions: Transaction[] = [
   {
     id: '6',
     counterparty: 'Gym Co.',
-    category: 'Fitness',
+    category: 'Bills',
     description: 'Gym membership',
     date: '29 may 2025',
     amount: '-35€',
@@ -75,7 +75,7 @@ export const transactions: Transaction[] = [
   {
     id: '7',
     counterparty: 'Spotify',
-    category: 'Entertainment',
+    category: 'Bills',
     description: 'Subscription fee',
     date: '28 may 2025',
     amount: '-10€',
@@ -85,7 +85,7 @@ export const transactions: Transaction[] = [
   {
     id: '8',
     counterparty: 'Electric Co.',
-    category: 'Utilities',
+    category: 'Bills',
     description: 'Electric bill',
     date: '27 may 2025',
     amount: '-60€',

--- a/mobile/src/screens/tabs/TransactionsScreen.tsx
+++ b/mobile/src/screens/tabs/TransactionsScreen.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import { StyleSheet, View, Text, ScrollView, TouchableOpacity, TextInput, Modal } from 'react-native';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Modal } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { Ionicons } from '@expo/vector-icons';
 import { transactions as initialTransactions, Transaction } from '../../data/transactions';
+
+const CATEGORIES = ['Groceries', 'Bills', 'Investments', 'Savings'];
 
 export const TransactionsScreen = () => {
   const [transactionList, setTransactionList] = useState<Transaction[]>(
@@ -46,69 +48,92 @@ export const TransactionsScreen = () => {
     <View style={styles.container}>
       <ScrollView>
         <Text style={styles.title}>TRANSACTIONS</Text>
-        {transactionList.map(transaction => (
-          <Swipeable
-            key={transaction.id}
-            renderLeftActions={() => (
-              <TouchableOpacity
-                style={[styles.swipeAction, styles.archiveAction]}
-                onPress={() => handleArchive(transaction.id)}
-              >
-                <Ionicons name="archive" size={24} color="#fff" />
-              </TouchableOpacity>
-            )}
-            renderRightActions={() => (
-              <TouchableOpacity
-                style={[styles.swipeAction, styles.deleteAction]}
-                onPress={() => handleDelete(transaction.id)}
-              >
-                <Ionicons name="trash" size={24} color="#fff" />
-              </TouchableOpacity>
-            )}
-          >
-            <TouchableOpacity style={styles.transactionItem} onPress={() => openModal(transaction)}>
-              <View
-                style={[
-                  styles.transactionIconContainer,
-                  transaction.type === 'sent' ? styles.sentIcon : styles.receivedIcon,
-                ]}
-              >
-                <Ionicons
-                  name={transaction.type === 'sent' ? 'arrow-up' : 'arrow-down'}
-                  size={20}
-                  color="#FFFFFF"
-                />
-              </View>
-              <View style={styles.transactionDetails}>
-                <Text style={styles.transactionCounterparty}>{transaction.counterparty}</Text>
-                <Text style={styles.transactionDescription}>{transaction.description}</Text>
-                <Text style={styles.transactionCategory}>{transaction.category}</Text>
-                <Text style={styles.transactionDate}>{transaction.date}</Text>
-              </View>
-              <Text
-                style={[
-                  styles.transactionAmount,
-                  transaction.type === 'sent' ? styles.sentAmount : styles.receivedAmount,
-                ]}
-              >
-                {transaction.amount}
-              </Text>
-            </TouchableOpacity>
-          </Swipeable>
-        ))}
+        {CATEGORIES.map(category => {
+          const items = transactionList.filter(t => t.category === category);
+          if (items.length === 0) return null;
+          return (
+            <View key={category}>
+              <Text style={styles.categoryHeader}>{category}</Text>
+              {items.map(transaction => (
+                <Swipeable
+                  key={transaction.id}
+                  renderLeftActions={() => (
+                    <TouchableOpacity
+                      style={[styles.swipeAction, styles.archiveAction]}
+                      onPress={() => handleArchive(transaction.id)}
+                    >
+                      <Ionicons name="archive" size={24} color="#fff" />
+                    </TouchableOpacity>
+                  )}
+                  renderRightActions={() => (
+                    <TouchableOpacity
+                      style={[styles.swipeAction, styles.deleteAction]}
+                      onPress={() => handleDelete(transaction.id)}
+                    >
+                      <Ionicons name="trash" size={24} color="#fff" />
+                    </TouchableOpacity>
+                  )}
+                >
+                  <TouchableOpacity
+                    style={styles.transactionItem}
+                    onPress={() => openModal(transaction)}
+                  >
+                    <View
+                      style={[
+                        styles.transactionIconContainer,
+                        transaction.type === 'sent'
+                          ? styles.sentIcon
+                          : styles.receivedIcon,
+                      ]}
+                    >
+                      <Ionicons
+                        name={transaction.type === 'sent' ? 'arrow-up' : 'arrow-down'}
+                        size={20}
+                        color="#FFFFFF"
+                      />
+                    </View>
+                    <View style={styles.transactionDetails}>
+                      <Text style={styles.transactionCounterparty}>{transaction.counterparty}</Text>
+                      <Text style={styles.transactionDescription}>{transaction.description}</Text>
+                      <Text style={styles.transactionCategory}>{transaction.category}</Text>
+                      <Text style={styles.transactionDate}>{transaction.date}</Text>
+                    </View>
+                    <Text
+                      style={[
+                        styles.transactionAmount,
+                        transaction.type === 'sent'
+                          ? styles.sentAmount
+                          : styles.receivedAmount,
+                      ]}
+                    >
+                      {transaction.amount}
+                    </Text>
+                  </TouchableOpacity>
+                </Swipeable>
+              ))}
+            </View>
+          );
+        })}
       </ScrollView>
       {selectedTransaction && (
         <Modal visible transparent animationType="slide">
           <View style={styles.modalOverlay}>
             <View style={styles.modalContent}>
               <Text style={styles.modalTitle}>{selectedTransaction.counterparty}</Text>
-              <TextInput
-                style={styles.modalInput}
-                value={tempCategory}
-                onChangeText={setTempCategory}
-                placeholder="Category"
-                placeholderTextColor="gray"
-              />
+              <View style={styles.categorySelect}>
+                {CATEGORIES.map(cat => (
+                  <TouchableOpacity
+                    key={cat}
+                    style={[
+                      styles.categoryOption,
+                      tempCategory === cat && styles.categoryOptionActive,
+                    ]}
+                    onPress={() => setTempCategory(cat)}
+                  >
+                    <Text style={styles.actionText}>{cat}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
               <View style={styles.modalActions}>
                 <TouchableOpacity style={styles.saveButton} onPress={saveCategory}>
                   <Text style={styles.actionText}>Save</Text>
@@ -141,6 +166,13 @@ const styles = StyleSheet.create({
     color: '#66BB6A',
     textAlign: 'center',
     marginBottom: 20,
+  },
+  categoryHeader: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 10,
+    marginBottom: 6,
   },
   transactionItem: {
     flexDirection: 'row',
@@ -253,15 +285,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 10,
   },
-  categoryInput: {
-    flex: 1,
-    backgroundColor: '#3a3a3a',
-    color: '#fff',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
-    marginRight: 8,
-  },
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.5)',
@@ -283,16 +306,22 @@ const styles = StyleSheet.create({
     marginBottom: 20,
     textAlign: 'center',
   },
-  modalInput: {
-   backgroundColor: '#3a3a3a',
-    color: '#fff',
-    paddingHorizontal: 12,
-    paddingVertical: 9,
-    borderRadius: 8,
-    fontSize: 16,
-    borderWidth: 1,
-    borderColor: '#555',
+  categorySelect: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
     marginBottom: 10,
+  },
+  categoryOption: {
+    backgroundColor: '#3a3a3a',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    marginBottom: 6,
+    marginRight: 6,
+  },
+  categoryOptionActive: {
+    backgroundColor: '#66BB6A',
   },
   modalActions: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- group transactions by four budget categories
- allow choosing category in transaction modal
- updated sample data to use new categories

## Testing
- `npx tsc -p mobile` *(fails: Cannot find module...)*
- `npm test` in mobile *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68429f36a650832f93b7ff6067c7f52a