### PR TITLE
Add category transaction view

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -16,6 +16,7 @@ import { RegisterScreen } from './src/screens/auth/RegisterScreen';
 import  {BudgetScreen}  from '@/screens/tabs/BudgetScreen';
 import { GoalScreen } from './src/screens/tabs/GoalScreen';
 import { MoreScreen } from './src/screens/tabs/MoreScreen';
+import { CategoryTransactionsScreen } from './src/screens/tabs/CategoryTransactionsScreen';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
 
@@ -111,6 +112,10 @@ export default function App() {
             <Stack.Screen name='Budget' component={BudgetScreen}/>
             <Stack.Screen name='Goals'  component={GoalScreen}/>
             <Stack.Screen name='More'  component={MoreScreen}/>
+            <Stack.Screen
+              name='CategoryTransactions'
+              component={CategoryTransactionsScreen}
+            />
           </Stack.Navigator>
         </NavigationContainer>
       </View>

--- a/mobile/src/screens/tabs/CategoryTransactionsScreen.tsx
+++ b/mobile/src/screens/tabs/CategoryTransactionsScreen.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { transactions } from '../../data/transactions';
+
+export const CategoryTransactionsScreen = ({ route, navigation }) => {
+  const { category } = route.params;
+  const items = transactions.filter(t => t.category === category);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Ionicons name="chevron-back" size={24} color="#FFFFFF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{category}</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <ScrollView>
+        {items.map(transaction => (
+          <View key={transaction.id} style={styles.transactionItem}>
+            <View
+              style={[
+                styles.transactionIconContainer,
+                transaction.type === 'sent' ? styles.sentIcon : styles.receivedIcon,
+              ]}
+            >
+              <Ionicons
+                name={transaction.type === 'sent' ? 'arrow-up' : 'arrow-down'}
+                size={20}
+                color="#FFFFFF"
+              />
+            </View>
+            <View style={styles.transactionDetails}>
+              <Text style={styles.transactionCounterparty}>{transaction.counterparty}</Text>
+              <Text style={styles.transactionDescription}>{transaction.description}</Text>
+              <Text style={styles.transactionDate}>{transaction.date}</Text>
+            </View>
+            <Text
+              style={[
+                styles.transactionAmount,
+                transaction.type === 'sent' ? styles.sentAmount : styles.receivedAmount,
+              ]}
+            >
+              {transaction.amount}
+            </Text>
+          </View>
+        ))}
+        {items.length === 0 && (
+          <Text style={styles.emptyText}>No transactions found.</Text>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1f1f1f',
+    padding: 15,
+    paddingTop: 40,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    color: '#66BB6A',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  transactionItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#2a2a2a',
+    padding: 15,
+    borderRadius: 10,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  transactionIconContainer: {
+    padding: 10,
+    borderRadius: 20,
+    marginRight: 15,
+  },
+  sentIcon: {
+    backgroundColor: '#444444',
+  },
+  receivedIcon: {
+    backgroundColor: '#66BB6A',
+  },
+  transactionDetails: {
+    flex: 1,
+  },
+  transactionCounterparty: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  transactionDescription: {
+    color: '#BBBBBB',
+    fontSize: 14,
+  },
+  transactionDate: {
+    color: 'gray',
+    fontSize: 12,
+  },
+  transactionAmount: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  sentAmount: {
+    color: '#FF5555',
+  },
+  receivedAmount: {
+    color: '#66BB6A',
+  },
+  emptyText: {
+    color: '#FFFFFF',
+    textAlign: 'center',
+    marginTop: 20,
+  },
+});
+

--- a/mobile/src/screens/tabs/StatisticsScreen.tsx
+++ b/mobile/src/screens/tabs/StatisticsScreen.tsx
@@ -1,5 +1,5 @@
 // Statistics screen showing spending data using a simple bar chart
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -10,14 +10,23 @@ import {
 import { BarChart } from 'react-native-chart-kit';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
+import { transactions } from '../../data/transactions';
 
-export default function StatisticsScreen() {
-  const categories = [
-    { label: 'Food expenses', value: 20, color: '#10B981' },
-    { label: 'Transportation', value: 6, color: '#60A5FA' },
-    { label: 'Light bill', value: 4, color: '#F59E0B' },
-    { label: 'Fun expenses', value: 8, color: '#EF4444' },
-  ];
+export default function StatisticsScreen({ navigation }: any) {
+  const categories = useMemo(() => {
+    const baseColors = ['#10B981', '#60A5FA', '#F59E0B', '#EF4444'];
+    const totals: Record<string, number> = {};
+    transactions.forEach(t => {
+      const amount = parseFloat(t.amount.replace('€', '').replace(',', '.'));
+      totals[t.category] = (totals[t.category] || 0) + Math.abs(amount);
+    });
+    const grand = Object.values(totals).reduce((sum, v) => sum + v, 0);
+    return Object.entries(totals).map(([label, val], idx) => ({
+      label,
+      value: grand ? Math.round((val / grand) * 100) : 0,
+      color: baseColors[idx % baseColors.length],
+    }));
+  }, []);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -65,12 +74,17 @@ export default function StatisticsScreen() {
           <Ionicons name="chevron-forward" size={28} color="#3ee06c" />
         </TouchableOpacity>
       </View>
-      <View style={styles.chartInfo}>
+      <TouchableOpacity
+        style={styles.chartInfo}
+        onPress={() =>
+          navigation.navigate('CategoryTransactions', { category: selected.label })
+        }
+      >
         <Text style={styles.chartLabel}>{selected.label}</Text>
         <Text style={styles.chartValue}>
           {selected.value > 0 ? `+${selected.value}%` : `${selected.value}%`}
         </Text>
-      </View>
+      </TouchableOpacity>
 
       <View style={styles.categoriesContainer}>
         {categories.map((cat, index) => (


### PR DESCRIPTION
## Summary
- compute statistics based on existing transactions
- allow tapping the percentage to open a filtered transaction list
- create `CategoryTransactionsScreen` to show items by category
- register the new screen in navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68494d0bb814832f9ac21fcc5ac95a60