### PR TITLE
Add animation to statistics page

### DIFF
--- a/mobile/src/components/SummaryCard.tsx
+++ b/mobile/src/components/SummaryCard.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Modal, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Modal, TouchableOpacity, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Transaction } from '../data/transactions';
 
 type Props = {
   transactions: Transaction[];
+  /** Optional style overrides for the card container */
+  style?: ViewStyle;
 };
 
-const SummaryCard: React.FC<Props> = ({ transactions }) => {
+const SummaryCard: React.FC<Props> = ({ transactions, style }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const income = transactions
@@ -32,7 +34,7 @@ const SummaryCard: React.FC<Props> = ({ transactions }) => {
           colors={["#0E0E0E", "#2C9C55", "#4ADE80"]}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
-          style={styles.card}
+          style={[styles.card, style]}
         >
           <Text style={styles.title}>Budget Left</Text>
           <Text style={styles.balance}>€{balance.toFixed(2)}</Text>

--- a/mobile/src/screens/tabs/StatisticsScreen.tsx
+++ b/mobile/src/screens/tabs/StatisticsScreen.tsx
@@ -1,11 +1,12 @@
 // Statistics screen showing spending data using a simple bar chart
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   Modal,
   StyleSheet,
+  Animated,
 } from 'react-native';
 import { BarChart } from 'react-native-chart-kit';
 import { Ionicons } from '@expo/vector-icons';
@@ -31,6 +32,17 @@ export default function StatisticsScreen({ navigation }: any) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [modalVisible, setModalVisible] = useState(false);
 
+  // Animation for bringing elements to life when the screen loads
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 600,
+      useNativeDriver: true,
+    }).start();
+  }, []);
+
   const selected = categories[selectedIndex];
 
   const chartData = {
@@ -55,14 +67,27 @@ export default function StatisticsScreen({ navigation }: any) {
         </View>
       </View>
 
-      <SummaryCard transactions={transactions} />
+      <Animated.View
+        style={{
+          opacity: fadeAnim,
+          transform: [
+            {
+              translateY: fadeAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [20, 0],
+              }),
+            },
+          ],
+        }}
+      >
+        <SummaryCard transactions={transactions} style={styles.slimSummaryCard} />
 
-      {/* Gráfico e navegação (estrutura básica restaurada) */}
-      <View style={[styles.chartContainer, { width: categories.length * 85 }]}>
-        <BarChart
-          data={chartData}
-          width={categories.length * 85}
-          height={200}
+        {/* Gráfico e navegação (estrutura básica restaurada) */}
+        <View style={[styles.chartContainer, { width: categories.length * 85 }]}>
+          <BarChart
+            data={chartData}
+            width={categories.length * 85}
+            height={200}
           fromZero
           showValuesOnTopOfBars
           withCustomBarColorFromData={true}
@@ -84,16 +109,16 @@ export default function StatisticsScreen({ navigation }: any) {
               strokeOpacity: 0.4,
             },
           }}
-          style={styles.chart}
-        />
-      </View>
+            style={styles.chart}
+          />
+        </View>
 
-      <View style={styles.categoriesContainer}>
-        {categories.map((cat, index) => (
-          <TouchableOpacity
-            key={cat.label}
-            style={styles.categoryBlock}
-            onPress={() => {
+        <View style={styles.categoriesContainer}>
+          {categories.map((cat, index) => (
+            <TouchableOpacity
+              key={cat.label}
+              style={styles.categoryBlock}
+              onPress={() => {
               setSelectedIndex(index);
               setModalVisible(true);
             }}
@@ -110,9 +135,10 @@ export default function StatisticsScreen({ navigation }: any) {
                 {cat.value > 0 ? `+${cat.value}%` : `${cat.value}%`}
               </Text>
             </View>
-          </TouchableOpacity>
-        ))}
-      </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </Animated.View>
 
       {modalVisible && (
         <Modal visible transparent animationType="fade">
@@ -266,5 +292,9 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 14,
     fontWeight: '600',
+  },
+  slimSummaryCard: {
+    width: '95%',
+    alignSelf: 'center',
   },
 });


### PR DESCRIPTION
## Summary
- allow custom styles in `SummaryCard`
- animate content in `StatisticsScreen`
- slim `SummaryCard` width in statistics page

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684a9ccf8460832f99e152b253d519ff