### PR TITLE
Connect goals to backend

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -16,6 +16,14 @@ export async function initDB() {
         created_at DATE NOT NULL DEFAULT CURRENT_DATE
         )`
 
+        await sql`CREATE TABLE IF NOT EXISTS goals(
+        id SERIAL PRIMARY KEY,
+        user_id VARCHAR(255) NOT NULL,
+        name VARCHAR(255) NOT NULL,
+        current DECIMAL(10,2) NOT NULL DEFAULT 0,
+        target DECIMAL(10,2) NOT NULL
+        )`
+
         console.log("Database initialized successfully")
     } catch (error) {
         console.log("Error initializing DB", error)

--- a/backend/controllers/goalsController.js
+++ b/backend/controllers/goalsController.js
@@ -1,0 +1,63 @@
+import { sql } from "../config/db.js";
+
+export async function getGoalsByUserId(req, res) {
+  try {
+    const { user_id } = req.params;
+    const goals = await sql`SELECT * FROM goals WHERE user_id = ${user_id} ORDER BY id`;
+    res.status(200).json(goals);
+  } catch (error) {
+    console.log("Error getting goals", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+export async function createGoal(req, res) {
+  try {
+    const { user_id, name, current, target } = req.body;
+    if (!user_id || !name || target === undefined) {
+      return res.status(400).json({ message: "All fields are required" });
+    }
+    const curr = current || 0;
+    const result = await sql`
+      INSERT INTO goals(user_id, name, current, target)
+      VALUES(${user_id}, ${name}, ${curr}, ${target})
+      RETURNING *`;
+    res.status(201).json(result[0]);
+  } catch (error) {
+    console.log("Error creating goal", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+export async function updateGoal(req, res) {
+  try {
+    const { id } = req.params;
+    const { name, current, target } = req.body;
+    const result = await sql`
+      UPDATE goals
+      SET name = ${name}, current = ${current}, target = ${target}
+      WHERE id = ${id}
+      RETURNING *`;
+    if (result.length === 0) {
+      return res.status(404).json({ message: "Goal not found" });
+    }
+    res.status(200).json(result[0]);
+  } catch (error) {
+    console.log("Error updating goal", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+export async function deleteGoal(req, res) {
+  try {
+    const { id } = req.params;
+    const result = await sql`DELETE FROM goals WHERE id = ${id} RETURNING *`;
+    if (result.length === 0) {
+      return res.status(404).json({ message: "Goal not found" });
+    }
+    res.status(200).json({ message: "Goal deleted" });
+  } catch (error) {
+    console.log("Error deleting goal", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}

--- a/backend/routes/goalsRoute.js
+++ b/backend/routes/goalsRoute.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { createGoal, deleteGoal, getGoalsByUserId, updateGoal } from "../controllers/goalsController.js";
+
+const router = express.Router();
+
+router.get('/:user_id', getGoalsByUserId);
+router.post('/', createGoal);
+router.put('/:id', updateGoal);
+router.delete('/:id', deleteGoal);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ import {initDB} from "./config/db.js"
 import rateLimiter from "./middleware/rateLimiter.js"
 
 import transactionRoute from "./routes/transactionsRoute.js"
+import goalsRoute from "./routes/goalsRoute.js"
 
 dotenv.config();
 
@@ -22,6 +23,7 @@ app.get("/", (req, res) => {
 });
 
 app.use("/api/transactions", transactionRoute);
+app.use("/api/goals", goalsRoute);
 
 
 

--- a/mobile/src/data/goals.ts
+++ b/mobile/src/data/goals.ts
@@ -1,5 +1,5 @@
 export interface Goal {
-  id: string;
+  id: number | string;
   /** Name/description of the saving goal */
   name: string;
   /** Current amount saved towards the goal */

--- a/mobile/src/screens/tabs/GoalScreen.tsx
+++ b/mobile/src/screens/tabs/GoalScreen.tsx
@@ -15,15 +15,21 @@ export const GoalScreen = () => {
   const [showEndPicker, setShowEndPicker] = useState(false);
 
   const handleCreateGoal = () => {
-    const goalData = {
-      goalName,
-      amount,
-      category,
-      recurrency,
-      startDate,
-      endDate,
-    };
-    console.log('Goal Created:', goalData);
+    fetch('http://localhost:5001/api/goals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: '1',
+        name: goalName,
+        current: 0,
+        target: parseFloat(amount) || 0,
+      }),
+    })
+      .then(() => {
+        setGoalName('');
+        setAmount('');
+      })
+      .catch(err => console.log('Error creating goal', err));
   };
 
   return (

--- a/mobile/src/screens/tabs/HomeScreen.tsx
+++ b/mobile/src/screens/tabs/HomeScreen.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Image, Modal, TextInput } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { Ionicons } from '@expo/vector-icons';
 import { goals as initialGoals, Goal } from '../../data/goals';
+
+const API_URL = 'http://localhost:5001';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { CompositeNavigationProp } from '@react-navigation/native';
@@ -37,6 +39,13 @@ const HomeScreen = ({ navigation }: { navigation: HomeScreenProps }) => {
   const [tempCurrent, setTempCurrent] = useState('');
   const [tempTarget, setTempTarget] = useState('');
 
+  useEffect(() => {
+    fetch(`${API_URL}/api/goals/1`)
+      .then(res => res.json())
+      .then(data => setGoalList(data))
+      .catch(err => console.log('Error fetching goals', err));
+  }, []);
+
   // Modal state for adding new goals
   const [addModalVisible, setAddModalVisible] = useState(false);
   const [newName, setNewName] = useState('');
@@ -52,39 +61,51 @@ const HomeScreen = ({ navigation }: { navigation: HomeScreenProps }) => {
 
   const saveGoal = () => {
     if (!selectedGoal) return;
-    setGoalList(prev =>
-      prev.map(g =>
-        g.id === selectedGoal.id
-          ? {
-              ...g,
-              name: tempName,
-              current: parseFloat(tempCurrent) || 0,
-              target: parseFloat(tempTarget) || 0,
-            }
-          : g
-      )
-    );
-    setSelectedGoal(null);
+    fetch(`${API_URL}/api/goals/${selectedGoal.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: tempName,
+        current: parseFloat(tempCurrent) || 0,
+        target: parseFloat(tempTarget) || 0,
+      }),
+    })
+      .then(res => res.json())
+      .then(updated => {
+        setGoalList(prev =>
+          prev.map(g => (g.id === selectedGoal.id ? updated : g))
+        );
+        setSelectedGoal(null);
+      })
+      .catch(err => console.log('Error updating goal', err));
   };
 
   const addGoal = () => {
-    setGoalList(prev => [
-      ...prev,
-      {
-        id: Date.now().toString(),
-        name: newName || `Goal ${prev.length + 1}`,
+    fetch(`${API_URL}/api/goals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: '1',
+        name: newName,
         current: parseFloat(newCurrent) || 0,
         target: parseFloat(newTarget) || 0,
-      },
-    ]);
-    setAddModalVisible(false);
-    setNewName('');
-    setNewCurrent('0');
-    setNewTarget('');
+      }),
+    })
+      .then(res => res.json())
+      .then(created => {
+        setGoalList(prev => [...prev, created]);
+        setAddModalVisible(false);
+        setNewName('');
+        setNewCurrent('0');
+        setNewTarget('');
+      })
+      .catch(err => console.log('Error creating goal', err));
   };
 
   const deleteGoal = (id: string) => {
-    setGoalList(prev => prev.filter(g => g.id !== id));
+    fetch(`${API_URL}/api/goals/${id}`, { method: 'DELETE' })
+      .then(() => setGoalList(prev => prev.filter(g => g.id !== id)))
+      .catch(err => console.log('Error deleting goal', err));
   };
 
   return (


### PR DESCRIPTION
## Summary
- create backend routes and controller for goals CRUD
- initialize `goals` table
- expose `/api/goals` endpoints from server
- fetch and update goals from mobile HomeScreen
- allow creating goals from GoalScreen

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68511ab05fb8832fa7e873abe581f94e