### PR TITLE
Fix auth API port

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
-PORT=5001
+PORT=8080
 DATABASE_URL=postgresql://neondb_owner:npg_86hxibwtXRKp@ep-square-field-a8dgf96x-pooler.eastus2.azure.neon.tech/neondb?sslmode=require
  
 EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bGl2aW5nLXRvdWNhbi0zNy5jbGVyay5hY2NvdW50cy5kZXYk
-EXPO_PUBLIC_API_URL=http://localhost:5001
+EXPO_PUBLIC_API_URL=http://localhost:8080
  
 UPSTASH_REDIS_REST_URL=https://strong-insect-37508.upstash.io
 UPSTASH_REDIS_REST_TOKEN=AZKEAAIjcDE2NDZlZWI4YzQzNGQ0N2NjYTVhYjVhMmJkN2JmYzJkM3AxMA

--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,4 @@
-PORT=5001
+PORT=8080
 DATABASE_URL=postgresql://neondb_owner:npg_86hxibwtXRKp@ep-square-field-a8dgf96x-pooler.eastus2.azure.neon.tech/neondb?sslmode=require
  
 EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bGl2aW5nLXRvdWNhbi0zNy5jbGVyay5hY2NvdW50cy5kZXYk

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,7 +15,7 @@ dotenv.config();
 
 const app = express();
 
-const PORT= process.env.PORT || 5001;
+const PORT= process.env.PORT || 8080;
 
 // middleware
 app.use(rateLimiter);

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -23,7 +23,7 @@ function getApiUrl() {
   }
   const host =
     Constants.manifest?.debuggerHost?.split(':').shift() || 'localhost';
-  return `http://${host}:5001`;
+  return `http://${host}:8080`;
 }
 
 const API_URL = getApiUrl();


### PR DESCRIPTION
## Summary
- switch backend port to 8080 because ports 5001/5002 are unavailable
- update env files and AuthContext to use the new port

## Testing
- `curl http://localhost:8080/api/auth/register`
- `curl http://localhost:8080/api/auth/login`


------
https://chatgpt.com/codex/tasks/task_e_68528abe290c832f809fa84081da3767