### PR TITLE
Fix registration endpoint and UI

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -3,9 +3,12 @@ import bcrypt from "bcrypt";
 
 export async function registerUser(req, res) {
     try {
-        const { username, email, password } = req.body;
-        if (!username || !email || !password) {
+        const { username, email, password, confirmPassword } = req.body;
+        if (!username || !email || !password || !confirmPassword) {
             return res.status(400).json({ message: "All fields are required" });
+        }
+        if (password !== confirmPassword) {
+            return res.status(400).json({ message: "Passwords do not match" });
         }
         const hashed = await bcrypt.hash(password, 10);
         await sql`
@@ -15,7 +18,7 @@ export async function registerUser(req, res) {
         res.status(201).json({ message: "Registration successful" });
     } catch (err) {
         if (err.code === '23505') {
-            res.status(400).json({ message: "Username or email already exists" });
+            res.status(409).json({ message: "Username or email already exists" });
         } else {
             console.error("Registration error", err);
             res.status(500).json({ message: "Internal server error" });

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -11,7 +11,12 @@ interface User {
 interface AuthContextType {
   user: User | null;
   login: (usernameOrEmail: string, password: string) => Promise<boolean>;
-  register: (username: string, email: string, password: string) => Promise<boolean>;
+  register: (
+    username: string,
+    email: string,
+    password: string,
+    confirmPassword: string
+  ) => Promise<boolean>;
   logout: () => Promise<void>;
 }
 
@@ -49,14 +54,23 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   };
 
-  const register = async (username: string, email: string, password: string) => {
+  const register = async (
+    username: string,
+    email: string,
+    password: string,
+    confirmPassword: string
+  ) => {
     try {
       const res = await fetch(`${API_URL}/api/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, email, password }),
+        body: JSON.stringify({ username, email, password, confirmPassword }),
       });
-      return res.ok;
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || 'Registration failed');
+      }
+      return true;
     } catch (err) {
       console.error('Register error', err);
       return false;

--- a/mobile/src/screens/auth/RegisterScreen.tsx
+++ b/mobile/src/screens/auth/RegisterScreen.tsx
@@ -24,12 +24,14 @@ export const RegisterScreen = () => {
       Alert.alert('Error', 'Passwords do not match');
       return;
     }
-    const success = await register(username, email, password);
-    if (success) {
-      Alert.alert('Success', 'Account created');
-      navigation.navigate('Login');
-    } else {
-      Alert.alert('Error', 'Registration failed');
+    try {
+      const success = await register(username, email, password, confirm);
+      if (success) {
+        Alert.alert('Success', 'Account created');
+        navigation.navigate('Login');
+      }
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Registration failed');
     }
   };
 

--- a/mobile/src/screens/tabs/CategoryTransactionsScreen.tsx
+++ b/mobile/src/screens/tabs/CategoryTransactionsScreen.tsx
@@ -3,7 +3,13 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-nati
 import { Ionicons } from '@expo/vector-icons';
 import { transactions } from '../../data/transactions';
 
-export const CategoryTransactionsScreen = ({ route, navigation }) => {
+export const CategoryTransactionsScreen = ({
+  route,
+  navigation,
+}: {
+  route: any;
+  navigation: any;
+}) => {
   const { category } = route.params;
   const items = transactions.filter(t => t.category === category);
 


### PR DESCRIPTION
## Summary
- validate confirm password on backend
- improve registration API to return proper errors
- pass confirm password from mobile app
- surface backend error messages in registration screen
- fix TypeScript error in CategoryTransactionsScreen

## Testing
- `npx tsc --noEmit -p mobile/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6852969bad7c832f85504678ffba3e67