### PR TITLE
Improve mobile register error handling

### DIFF
--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -66,9 +66,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password, confirmPassword }),
       });
+
       if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.message || 'Registration failed');
+        const contentType = res.headers.get('content-type');
+        let message = 'Registration failed';
+        if (contentType && contentType.includes('application/json')) {
+          const data = await res.json();
+          message = data.message || message;
+        }
+        throw new Error(message);
       }
       return true;
     } catch (err) {


### PR DESCRIPTION
## Summary
- avoid parsing non-JSON responses in AuthContext register method

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6852a2055c98832f82c0c96c513f72e1