### PR TITLE
Fix duplicate registration and login lookup

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -17,6 +17,9 @@ export async function initDB() {
             email VARCHAR(255) UNIQUE NOT NULL,
             password VARCHAR(255) NOT NULL
         )`;
+        // Ensure unique constraints exist even if table already existed
+        await sql`ALTER TABLE users ADD CONSTRAINT IF NOT EXISTS unique_username UNIQUE (username)`;
+        await sql`ALTER TABLE users ADD CONSTRAINT IF NOT EXISTS unique_email UNIQUE (email)`;
         await sql`CREATE TABLE IF NOT EXISTS transactions(
         id SERIAL PRIMARY KEY,
         user_id VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- ensure username and email aren't reused in register controller
- fetch the most recent matching user when logging in
- reinforce unique constraints in DB initialization

## Testing
- `npm test` (fails: Missing script)
- `npm test` in mobile (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_6852a67adb00832fbdfaf47f36c54524